### PR TITLE
docs: align project branding and add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report a bug in Eidolon
+labels: bug
+---
+
+## Description
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps To Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- Describe what you expected to happen. -->
+
+## Screenshots
+<!-- If applicable, add screenshots or logs to help explain your problem. -->
+
+## Environment
+- OS:
+- Roblox Studio version:
+
+## Additional Context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for Eidolon
+labels: enhancement
+---
+
+## Summary
+<!-- Describe the feature you would like to see. -->
+
+## Motivation
+<!-- Why is this feature valuable? -->
+
+## Alternatives
+<!-- Describe any alternative solutions or features you've considered. -->
+
+## Additional Context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+- _Provide a concise description of the changes._
+
+## Testing
+- [ ] `rojo build`
+- [ ] Other checks:
+
+## Ecosystem Impact
+- _Does this change interact with GrandTheftLux, BladeAeternum, or NeuroBloom within the Divina Network?_
+
+## Additional Notes
+- _Reference issues or additional context._
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 📝 PETFINITY Changelog
+# 📝 Eidolon Changelog
+
+## [Unreleased]
+
+### Added
+- Documentation linking Eidolon to GrandTheftLux, BladeAeternum, and NeuroBloom within the Divina Network
 
 ## [v1.0.0] - 2024-03-03 🚀 Initial Release
 

--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -1,4 +1,4 @@
-# 🚀 PETFINITY Launch Checklist
+# 🚀 Eidolon Launch Checklist
 
 ## 1️⃣ Final Testing Phase
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# Petfinity - AI-Generated & Persistent World System
+# Eidolon - AI-Generated & Persistent World System
 
 ## Overview
 
-Petfinity is a procedurally generated world system for Roblox, featuring AI-driven terrain generation, biome blending, structure placement, and world persistence. The system is designed to create immersive, unique environments that persist across play sessions.
+Eidolon is a procedurally generated world system for Roblox, featuring AI-driven terrain generation, biome blending, structure placement, and world persistence. The system is designed to create immersive, unique environments that persist across play sessions.
 
-![Petfinity](https://example.com/petfinity_banner.png)
+For source code and issue tracking, visit the [GitHub repository](https://github.com/DivinaNetwork/Eidolon).
+
+![Eidolon](https://example.com/eidolon_banner.png)
+
+## Ecosystem Integration
+
+Eidolon anchors the **Divina Network** by supplying persistent, AI-crafted worlds to upcoming experiences like [GrandTheftLux](https://github.com/DivinaNetwork/GrandTheftLux). Forthcoming modules—**BladeAeternum** for combat choreography and **NeuroBloom** for adaptive cognition—will plug into Eidolon to deliver a cohesive metaverse across titles.
 
 ## Features
 
@@ -145,11 +151,12 @@ Lush water-rich areas in the midst of arid regions.
 - Quest system leveraging procedural generation
 - User interface for world customization
 - World minimap visualization
+- Integration hooks for Divina Network modules (BladeAeternum, NeuroBloom) to support cross-title experiences like GrandTheftLux
 
 ## Credits
 
-Created by Your Precious Kitten 💖 for the Petfinity project.
+Created by Your Precious Kitten 💖 for the Eidolon project.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details. 
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/RojoProject.json
+++ b/RojoProject.json
@@ -1,5 +1,5 @@
 {
-    "name": "Petfinity",
+    "name": "Eidolon",
     "tree": {
         "$className": "DataModel",
         "ReplicatedStorage": {

--- a/default.project.json
+++ b/default.project.json
@@ -1,5 +1,5 @@
 {
-    "name": "Petfinity",
+    "name": "Eidolon",
     "tree": {
         "$className": "DataModel",
         "ReplicatedStorage": {


### PR DESCRIPTION
## Summary
- rename project to Eidolon in docs and config
- add GitHub issue and PR templates
- reference Divina Network ecosystem in docs

## Testing
- `cargo install rojo`
- `rojo build --output /tmp/build.rbxm` *(fails: Rojo project referred to a file using $path that could not be turned into a Roblox Instance)*

------
https://chatgpt.com/codex/tasks/task_e_688d92891ce0832586a176d689a0be35