### PR TITLE
feat: add council report scheduling and guardian relays

### DIFF
--- a/serafina/.env.example
+++ b/serafina/.env.example
@@ -1,0 +1,24 @@
+# Discord application token
+DISCORD_TOKEN=
+# Discord application client ID
+CLIENT_ID=
+# Discord guild where commands live
+GUILD_ID=
+# Council report channel
+CHN_COUNCIL=
+# Guardian relay channel
+CHN_GUARDIANS=
+# Comma-separated allowed guardian names
+GUARDIAN_NAMES=Athena,Serafina,ShadowFlowers
+# Optional webhook for Lilybear styled messages
+WH_LILYBEAR=
+# MCP service URL
+MCP_URL=
+# Comma-separated list of GitHub repos owner/name
+NAV_REPOS=owner/repo
+# URL of Unity bridge service for guardian messages
+UNITY_BRIDGE_URL=http://localhost:3000/relay
+# Sibling mesh nodes for handshake protocol (comma-separated URLs)
+MESH_NODES=
+# Name of this node within the mesh
+NODE_NAME=serafina

--- a/serafina/README.md
+++ b/serafina/README.md
@@ -1,0 +1,23 @@
+# Serafina Bot Extensions
+
+This directory hosts experimental add-ons for the Serafina Discord bot.
+
+## Features
+- Scheduled **nightly council report** posted at 08:00 UTC.
+- Manual slash command `/council-report-now` for on-demand reports.
+- Guardian relay: messages like `!whisper Athena <msg>` in the guardian
+  channel are forwarded to the Unity bridge service. Only guardians listed
+  in `GUARDIAN_NAMES` will be relayed, preventing arbitrary targets.
+- Mesh handshake: on startup, Serafina pings sibling services listed in
+  `MESH_NODES` to announce presence and capabilities.
+
+## Setup
+1. Copy `.env.example` to `.env` and fill in secrets like `DISCORD_TOKEN`, `CLIENT_ID`, and channel IDs.
+2. Install dependencies: `npm install`.
+3. Start the bot: `npm start` (uses [`tsx`](https://github.com/esbuild-kit/tsx) and requires Node >=18).
+
+To participate in the cross-repo mesh, ensure `MESH_NODES` and `NODE_NAME`
+are set in your `.env`.
+
+The bot assumes a companion Unity scene running the `LilybearOpsBus`
+with guardians listening for relay payloads.

--- a/serafina/package.json
+++ b/serafina/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "serafina",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/router.ts",
+    "test": "echo 'no tests yet'"
+  },
+  "dependencies": {
+    "discord.js": "^14.14.1",
+    "node-cron": "^3.0.3",
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "tsx": "^3.12.7"
+  }
+}

--- a/serafina/src/meshHandshake.ts
+++ b/serafina/src/meshHandshake.ts
@@ -1,0 +1,45 @@
+import fetch from 'node-fetch';
+
+interface HandshakePayload {
+  name: string;
+  version: string;
+  timestamp: string;
+  capabilities: string[];
+}
+
+/**
+ * Perform handshake with sibling nodes defined in MESH_NODES.
+ * Each node should expose POST /mesh/handshake.
+ */
+export async function performMeshHandshake(): Promise<void> {
+  const nodes = (process.env.MESH_NODES || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!nodes.length) return;
+
+  const payload: HandshakePayload = {
+    name: process.env.NODE_NAME || 'serafina',
+    version: process.env.npm_package_version || '0.0.0',
+    timestamp: new Date().toISOString(),
+    capabilities: ['discord-router', 'nightly-report'],
+  };
+
+  for (const base of nodes) {
+    const url = base.replace(/\/$/, '') + '/mesh/handshake';
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        console.log(`mesh handshake ok with ${base}`);
+      } else {
+        console.warn(`mesh handshake failed with ${base}: ${res.status}`);
+      }
+    } catch (err) {
+      console.warn(`mesh handshake error with ${base}`, err);
+    }
+  }
+}

--- a/serafina/src/nightlyReport.ts
+++ b/serafina/src/nightlyReport.ts
@@ -1,0 +1,108 @@
+import 'dotenv/config';
+import fetch from 'node-fetch';
+import cron from 'node-cron';
+import {
+  Client,
+  EmbedBuilder,
+  TextChannel,
+} from 'discord.js';
+
+// ------------------------------
+// Utility to grab system health from MCP
+// ------------------------------
+async function getMcpStatus(): Promise<string> {
+  try {
+    const r = await fetch(`${process.env.MCP_URL}/ask-gemini`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Summarize system health in one sentence.' }),
+    });
+    const j = await r.json().catch(() => ({ response: '(no data)' }));
+    return j.response || '(no data)';
+  } catch {
+    return '(MCP unreachable)';
+  }
+}
+
+// ------------------------------
+// Lightweight GitHub commit digest
+// ------------------------------
+async function getRepoDigest(repo: string): Promise<string> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const url = `https://api.github.com/repos/${repo}/commits?since=${encodeURIComponent(
+    since,
+  )}&per_page=5`;
+  try {
+    const r = await fetch(url, {
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!r.ok) return `• ${repo}: no recent commits`;
+    const commits = (await r.json()) as any[];
+    if (!commits.length) return `• ${repo}: 0 commits in last 24h`;
+    const lines = commits.map(
+      (c) =>
+        `• ${repo}@${(c.sha || '').slice(0, 7)} — ${c.commit.message.split('\n')[0]}`,
+    );
+    return lines.join('\n');
+  } catch {
+    return `• ${repo}: (error fetching commits)`;
+  }
+}
+
+// ------------------------------
+// Build report embed used for both scheduled and manual dispatch
+// ------------------------------
+async function buildReportEmbed(): Promise<EmbedBuilder> {
+  const mcp = await getMcpStatus();
+  const repos = (process.env.NAV_REPOS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const repoLines = repos.length
+    ? (await Promise.all(repos.map(getRepoDigest))).join('\n')
+    : '—';
+
+  return new EmbedBuilder()
+    .setTitle('🌙 Nightly Council Report')
+    .setDescription('Summary of the last 24h across our realm.')
+    .setColor(0x9b59b6)
+    .addFields(
+      { name: 'System Health (MCP)', value: mcp.slice(0, 1024) || '—' },
+      { name: 'Recent Commits', value: repoLines.slice(0, 1024) || '—' },
+    )
+    .setFooter({ text: 'Reported by Lilybear' })
+    .setTimestamp(new Date());
+}
+
+// ------------------------------
+// Manual dispatch used by slash command
+// ------------------------------
+export async function sendCouncilReport(client: Client): Promise<void> {
+  const ch = client.channels.cache.get(
+    process.env.CHN_COUNCIL as string,
+  ) as TextChannel | undefined;
+  const embed = await buildReportEmbed();
+
+  if (process.env.WH_LILYBEAR) {
+    await fetch(process.env.WH_LILYBEAR, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ embeds: [embed.toJSON()] }),
+    });
+  } else if (ch) {
+    await ch.send({ embeds: [embed] });
+  }
+}
+
+// ------------------------------
+// Scheduler setup invoked on bot start
+// ------------------------------
+export function scheduleNightlyCouncilReport(client: Client): void {
+  cron.schedule(
+    '0 8 * * *',
+    () => {
+      void sendCouncilReport(client);
+    },
+    { timezone: 'UTC' },
+  );
+}

--- a/serafina/src/router.ts
+++ b/serafina/src/router.ts
@@ -1,0 +1,122 @@
+import 'dotenv/config';
+import fetch from 'node-fetch';
+import {
+  Client,
+  GatewayIntentBits,
+  REST,
+  Routes,
+  SlashCommandBuilder,
+} from 'discord.js';
+import {
+  scheduleNightlyCouncilReport,
+  sendCouncilReport,
+} from './nightlyReport.js';
+import { performMeshHandshake } from './meshHandshake.js';
+
+// Allowed guardians are defined in env for security. Comparison is case-insensitive
+// but original casing is preserved when relaying to the Unity bridge so that
+// guardian scripts can match their `GuardianName` exactly.
+const allowedGuardians = (process.env.GUARDIAN_NAMES || '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+// Discord client with message intent so guardians can be triggered
+export const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+  ],
+});
+
+// ------------------------------
+// Slash command registration
+// ------------------------------
+const commands = [
+  new SlashCommandBuilder()
+    .setName('council-report-now')
+    .setDescription('Dispatch the nightly council report immediately'),
+];
+
+async function registerCommands(): Promise<void> {
+  const rest = new REST({ version: '10' }).setToken(
+    process.env.DISCORD_TOKEN as string,
+  );
+  await rest.put(
+    Routes.applicationGuildCommands(
+      process.env.CLIENT_ID as string,
+      process.env.GUILD_ID as string,
+    ),
+    { body: commands.map((c) => c.toJSON()) },
+  );
+}
+
+// ------------------------------
+// Utility to relay guardian messages to Unity bridge service
+// ------------------------------
+async function relayToUnity(guardian: string, message: string): Promise<void> {
+  const url = process.env.UNITY_BRIDGE_URL;
+  if (!url) {
+    console.warn('UNITY_BRIDGE_URL not set; skipping relay');
+    return;
+  }
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ guardian, message }),
+    });
+  } catch (err) {
+    console.error('relay error', err);
+  }
+}
+
+// ------------------------------
+// Handle Discord messages intended for guardians.
+// Format: !whisper <guardian> <message>
+// ------------------------------
+client.on('messageCreate', (msg) => {
+  if (msg.author.bot) return;
+  if (msg.channel.id !== process.env.CHN_GUARDIANS) return;
+
+  const match = msg.content.match(/^!whisper\s+(\w+)\s+(.+)/i);
+  if (!match) return;
+
+  const [, guardianRaw, text] = match;
+  const guardian = guardianRaw.trim();
+  // Respect whitelist when provided to avoid arbitrary guardian names
+  if (
+    allowedGuardians.length &&
+    !allowedGuardians.includes(guardian.toLowerCase())
+  ) {
+    console.warn(`guardian ${guardian} not in whitelist; ignoring`);
+    return;
+  }
+  void relayToUnity(guardian, text);
+});
+
+// ------------------------------
+// Slash command handling
+// ------------------------------
+client.on('interactionCreate', async (interaction) => {
+  if (!interaction.isChatInputCommand()) return;
+
+  if (interaction.commandName === 'council-report-now') {
+    await interaction.deferReply({ ephemeral: true });
+    await sendCouncilReport(client);
+    await interaction.editReply('Council report dispatched.');
+  }
+});
+
+// ------------------------------
+// Startup
+// ------------------------------
+client.once('ready', () => {
+  console.log('Serafina online as', client.user?.tag);
+  scheduleNightlyCouncilReport(client);
+  void performMeshHandshake();
+});
+
+await registerCommands();
+await client.login(process.env.DISCORD_TOKEN);

--- a/unity/Assets/GameDinVR/Scripts/GuardianBase.cs
+++ b/unity/Assets/GameDinVR/Scripts/GuardianBase.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+/// <summary>
+/// Base behaviour for all guardians. Listens to the ops bus and responds
+/// when addressed.
+/// </summary>
+public class GuardianBase : MonoBehaviour {
+    [Header("Identity")] public string GuardianName = "Guardian";
+    [Header("Role")] public string Role = "Undefined";
+
+    protected virtual void OnEnable(){
+        if (LilybearOpsBus.I != null)
+            LilybearOpsBus.I.OnWhisper += HandleWhisper;
+    }
+    protected virtual void OnDisable(){
+        if (LilybearOpsBus.I != null)
+            LilybearOpsBus.I.OnWhisper -= HandleWhisper;
+    }
+
+    void HandleWhisper(string from, string to, string message){
+        if (to == GuardianName || to == "*"){
+            Debug.Log($"[{GuardianName}] received from {from}: {message}");
+            OnMessage(from, message);
+        }
+    }
+
+    public virtual void OnMessage(string from, string message) { }
+
+    protected void Whisper(string to, string message){
+        LilybearOpsBus.I?.Say(GuardianName, to, message);
+    }
+}

--- a/unity/Assets/GameDinVR/Scripts/Guardians/AthenaGuardian.cs
+++ b/unity/Assets/GameDinVR/Scripts/Guardians/AthenaGuardian.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents Athena, the strategist guardian.
+/// Replies with a simple status when addressed with the word "status".
+/// </summary>
+public class AthenaGuardian : GuardianBase {
+    void Start(){ GuardianName = "Athena"; Role = "Strategy & Intelligence"; }
+
+    public override void OnMessage(string from, string message){
+        if (message.Contains("status")){
+            Whisper("Lilybear", "Athena: All systems nominal.");
+        }
+    }
+}

--- a/unity/Assets/GameDinVR/Scripts/Guardians/SerafinaGuardian.cs
+++ b/unity/Assets/GameDinVR/Scripts/Guardians/SerafinaGuardian.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+/// <summary>
+/// Serafina routes blessings to ShadowFlowers when asked.
+/// </summary>
+public class SerafinaGuardian : GuardianBase {
+    void Start(){ GuardianName = "Serafina"; Role = "Comms & Routing"; }
+
+    public override void OnMessage(string from, string message){
+        if (message.StartsWith("bless")){
+            Whisper("ShadowFlowers", "Please deliver a blessing to the hall.");
+        }
+    }
+}

--- a/unity/Assets/GameDinVR/Scripts/Guardians/ShadowFlowersGuardian.cs
+++ b/unity/Assets/GameDinVR/Scripts/Guardians/ShadowFlowersGuardian.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+/// <summary>
+/// ShadowFlowers offers blessings when prompted.
+/// </summary>
+public class ShadowFlowersGuardian : GuardianBase {
+    public TextMesh BlessingText;
+
+    void Start(){ GuardianName = "ShadowFlowers"; Role = "Sentiment & Rituals"; }
+
+    public override void OnMessage(string from, string message){
+        if (message.Contains("blessing")){
+            var line = "\uD83C\uDF38 May your path be protected and your heart be held.";
+            if (BlessingText) BlessingText.text = line;
+            Whisper("Lilybear", "Blessing delivered.");
+        }
+    }
+}

--- a/unity/Assets/GameDinVR/Scripts/LilybearController.cs
+++ b/unity/Assets/GameDinVR/Scripts/LilybearController.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+/// <summary>
+/// Lilybear acts as voice and operations hub. For demo purposes it echoes
+/// `/route <msg>` commands to all guardians.
+/// </summary>
+public class LilybearController : GuardianBase {
+    [TextArea] public string LastMessage;
+
+    void Start(){
+        GuardianName = "Lilybear";
+        Role = "Voice & Operations";
+    }
+
+    public override void OnMessage(string from, string message){
+        LastMessage = $"{from}: {message}";
+        if (message.StartsWith("/route ")){
+            var payload = message.Substring(7);
+            Whisper("*", payload);
+        }
+    }
+
+    [ContextMenu("Test Whisper")]
+    void TestWhisper(){
+        Whisper("*", "The council is assembled.");
+    }
+}

--- a/unity/Assets/GameDinVR/Scripts/LilybearOpsBus.cs
+++ b/unity/Assets/GameDinVR/Scripts/LilybearOpsBus.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+using System;
+
+/// <summary>
+/// Simple in-scene event bus so guardians can whisper to each other.
+/// </summary>
+public class LilybearOpsBus : MonoBehaviour {
+    public static LilybearOpsBus I;
+    public delegate void Whisper(string from, string to, string message);
+    public event Whisper OnWhisper;
+
+    void Awake(){ I = this; }
+
+    public void Say(string from, string to, string message){
+        OnWhisper?.Invoke(from, to, message);
+        Debug.Log($"[LilybearBus] {from} → {to}: {message}");
+    }
+}

--- a/unity/Assets/GameDinVR/Scripts/OSC/OSCTextBridge.cs
+++ b/unity/Assets/GameDinVR/Scripts/OSC/OSCTextBridge.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+/// <summary>
+/// Placeholder script for future OSC bridge; exposes a method to set text
+/// from external calls.
+/// </summary>
+public class OSCTextBridge : MonoBehaviour {
+    public TextMesh Target;
+    public void SetText(string s){ if (Target) Target.text = s; }
+}

--- a/unity/README.md
+++ b/unity/README.md
@@ -1,0 +1,25 @@
+# Unity Guardian Scripts
+
+Proof-of-concept scripts demonstrating how guardians in a VRChat world can
+communicate via the `LilybearOpsBus`. They are designed to receive messages
+relayed from the Serafina Discord bot.
+
+## Usage
+
+1. In a VCC-compatible Unity project, create an empty GameObject and attach
+   `LilybearOpsBus` to act as the scene's whisper router.
+2. Add `LilybearController` to another empty GameObject. This represents the
+   operations hub that can broadcast to all guardians.
+3. For each guardian (e.g. Athena, Serafina, ShadowFlowers), create an empty
+   GameObject and attach the corresponding `*Guardian` script.
+4. Optionally, place a `TextMesh` in the scene and assign it to
+   `ShadowFlowersGuardian.BlessingText` to visualize blessings.
+5. Press Play and invoke `Test Whisper` from the `LilybearController`
+   context menu to verify cross-guardian messaging.
+
+When the Serafina Discord bot receives `!whisper <guardian> <message>` in the
+configured guardian channel, it forwards the message to the Unity bridge service
+(`UNITY_BRIDGE_URL`), which then calls `LilybearOpsBus.Say` with the provided
+guardian and message.
+
+Place the C# scripts under `Assets/GameDinVR/Scripts` inside your Unity project.


### PR DESCRIPTION
## Summary
- add nightly council report scheduler with manual `/council-report-now` slash command
- relay guardian messages from Discord to Unity bridge with safe env handling and whitelist support
- provide sample Unity guardian scripts and usage docs for Lilybear bus messaging
- expose `CLIENT_ID` env and `npm start` script using tsx
- introduce mesh handshake protocol for cross-repo awareness

## Testing
- `cd serafina && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a8e500bc8325a0a3af0031bdeda3